### PR TITLE
`New-ZipEntry` - Use file's `.FullName` if no `-EntryPath` is provided

### DIFF
--- a/docs/en-US/Compress-GzipArchive.md
+++ b/docs/en-US/Compress-GzipArchive.md
@@ -17,8 +17,8 @@ Creates a Gzip compressed file from specified paths or input bytes.
 
 ```powershell
 Compress-GzipArchive
-    [-Path] <String[]>
-    [-Destination] <String>
+    -Path <String[]>
+    -Destination <String>
     [-CompressionLevel <CompressionLevel>]
     [-Update]
     [-Force]
@@ -31,7 +31,7 @@ Compress-GzipArchive
 ```powershell
 Compress-GzipArchive
     -LiteralPath <String[]>
-    [-Destination] <String>
+    -Destination <String>
     [-CompressionLevel <CompressionLevel>]
     [-Update]
     [-Force]
@@ -44,7 +44,7 @@ Compress-GzipArchive
 ```powershell
 Compress-GzipArchive
     -InputBytes <Byte[]>
-    [-Destination] <String>
+    -Destination <String>
     [-CompressionLevel <CompressionLevel>]
     [-Update]
     [-Force]

--- a/docs/en-US/Compress-ZipArchive.md
+++ b/docs/en-US/Compress-ZipArchive.md
@@ -17,7 +17,7 @@ The `Compress-ZipArchive` cmdlet creates a compressed, or zipped, archive file f
 
 ```powershell
 Compress-ZipArchive
-    [-Path] <String[]>
+    -Path <String[]>
     -Destination <String>
     [-CompressionLevel <CompressionLevel>]
     [-Update]

--- a/docs/en-US/ConvertFrom-GzipString.md
+++ b/docs/en-US/ConvertFrom-GzipString.md
@@ -15,7 +15,7 @@ Expands Gzip Base64 compressed input strings.
 
 ```powershell
 ConvertFrom-GzipString
-    [-InputObject] <String[]>
+    -InputObject <String[]>
     [[-Encoding] <Encoding>]
     [-Raw]
     [<CommonParameters>]

--- a/docs/en-US/ConvertFrom-GzipString.md
+++ b/docs/en-US/ConvertFrom-GzipString.md
@@ -16,7 +16,7 @@ Expands Gzip Base64 compressed input strings.
 ```powershell
 ConvertFrom-GzipString
     -InputObject <String[]>
-    [[-Encoding] <Encoding>]
+    [-Encoding <Encoding>]
     [-Raw]
     [<CommonParameters>]
 ```

--- a/docs/en-US/ConvertTo-GzipString.md
+++ b/docs/en-US/ConvertTo-GzipString.md
@@ -15,7 +15,7 @@ Creates a Gzip Base64 compressed string from a specified input string or strings
 
 ```powershell
 ConvertTo-GzipString
-    [-InputObject] <String[]>
+    -InputObject <String[]>
     [-Encoding <Encoding>]
     [-CompressionLevel <CompressionLevel>]
     [-AsByteStream]

--- a/docs/en-US/Expand-GzipArchive.md
+++ b/docs/en-US/Expand-GzipArchive.md
@@ -17,7 +17,7 @@ Expands a Gzip compressed file from a specified File Path or Paths.
 
 ```powershell
 Expand-GzipArchive
-    [-Path] <String[]>
+    -Path <String[]>
     [-Raw]
     [<CommonParameters>]
 ```
@@ -26,7 +26,7 @@ Expand-GzipArchive
 
 ```powershell
 Expand-GzipArchive
-    [-Path] <String[]>
+    -Path <String[]>
     -Destination <String>
     [-Encoding <Encoding>]
     [-PassThru]

--- a/docs/en-US/Expand-ZipEntry.md
+++ b/docs/en-US/Expand-ZipEntry.md
@@ -16,7 +16,7 @@ Expands Zip Archive Entries to a destination directory.
 ```powershell
 Expand-ZipEntry
     -InputObject <ZipEntryBase[]>
-    [[-Destination] <String>]
+    [-Destination <String>]
     [-Force]
     [-PassThru]
     [<CommonParameters>]

--- a/docs/en-US/Get-ZipEntry.md
+++ b/docs/en-US/Get-ZipEntry.md
@@ -17,7 +17,7 @@ Lists zip entries from one or more specified Zip Archives.
 
 ```powershell
 Get-ZipEntry
-   [-Path] <String[]>
+   -Path <String[]>
    [-Type <String>]
    [-Include <String[]>]
    [-Exclude <String[]>]

--- a/docs/en-US/Get-ZipEntry.md
+++ b/docs/en-US/Get-ZipEntry.md
@@ -68,7 +68,7 @@ The `-Type` parameter supports filtering by `Archive` or `Directory`.
 ```powershell
 PS ..\pwsh> Get-ZipEntry .\PSCompression.zip -Include PSCompression/docs/en-us*
 
-   Directory: PSCompression/docs/en-US/
+   Directory: /PSCompression/docs/en-US/
 
 Type                    LastWriteTime  CompressedSize            Size Name
 ----                    -------------  --------------            ---- ----
@@ -89,7 +89,7 @@ Archive            2/22/2024  1:19 PM         1.55 KB         5.35 KB Set-ZipEnt
 
 PS ..\pwsh> Get-ZipEntry .\PSCompression.zip -Include PSCompression/docs/en-us* -Exclude *en-US/Compress*, *en-US/Remove*
 
-   Directory: PSCompression/docs/en-US/
+   Directory: /PSCompression/docs/en-US/
 
 Type                    LastWriteTime  CompressedSize            Size Name
 ----                    -------------  --------------            ---- ----
@@ -106,8 +106,10 @@ Archive            2/22/2024  1:19 PM       741.00  B         2.16 KB Rename-Zip
 Archive            2/22/2024  1:19 PM         1.55 KB         5.35 KB Set-ZipEntryContent.md
 ```
 
-Inclusion and Exclusion patterns are applied to the entries relative path.
-Exclusions are applied after the inclusions.
+> [!NOTE]
+>
+> - Inclusion and Exclusion patterns are applied to the entries relative path.
+> - Exclusions are applied after the inclusions.
 
 ## PARAMETERS
 

--- a/docs/en-US/New-ZipEntry.md
+++ b/docs/en-US/New-ZipEntry.md
@@ -17,9 +17,9 @@ Creates zip entries from one or more specified entry relative paths.
 
 ```powershell
 New-ZipEntry
-   [-Value <String[]>]
    -Destination <String>
    -EntryPath <String[]>
+   [-Value <String[]>]
    [-CompressionLevel <CompressionLevel>]
    [-Encoding <Encoding>]
    [-Force]
@@ -31,8 +31,8 @@ New-ZipEntry
 ```powershell
 New-ZipEntry
    -Destination <String>
-   -EntryPath <String[]>
-   [-SourcePath <String>]
+   -SourcePath <String>
+   [-EntryPath <String[]>]
    [-CompressionLevel <CompressionLevel>]
    [-Force]
    [<CommonParameters>]
@@ -46,12 +46,12 @@ Entry paths, _arguments of the `-EntryPath` parameter_, are always normalized, a
 
 | Input                          | Normalized As               |
 | ------------------------------ | --------------------------- |
-| `path\to\mynewentry.ext`       | `path/to/mynewentry.ext`    |
-| `\path\to\newdirectory\`       | `path/to/newdirectory/`     |
+| `C:\path\to\mynewentry.ext`    | `path/to/mynewentry.ext`    |
+| `\\path\to\newdirectory\`      | `path/to/newdirectory/`     |
 | `path\to\very/\random\/path\\` | `path/to/very/random/path/` |
 
 > [!TIP]
-> The `[PSCompression.Extensions.PathExtensions]::NormalizePath(string path)` static method is available as a public API if you would like to normalize your paths before creating new entries.
+> The `[PSCompression.Extensions.PathExtensions]::NormalizePath(string path)` static method is available as a public API if you want to normalize your paths before creating new entries.
 
 In addition, `New-ZipEntry` can set the content of the entries that it creates from string input or by specifying a source file path.
 
@@ -89,25 +89,26 @@ world
 !
 ```
 
-The cmdlet prevents creating entries in a destination Zip archive if an entry with the same relative path already exists. You can use the `-Force` parameter to overwrite them.
+> [!TIP]
+> The cmdlet prevents creating entries in a destination Zip archive if an entry with the same relative path already exists. You can use the `-Force` parameter to overwrite them.
 
 ### Example 3: Create entries with content from a source file path
 
 ```powershell
 PS ..\pwsh> $file = 'hello world!' | New-Item mytestfile.txt
-PS ..\pwsh> New-ZipEntry .\test.zip -EntryPath newentry.txt -SourcePath $file.FullName
+PS ..\pwsh> New-ZipEntry .\test.zip -SourcePath $file.FullName -EntryPath newentry.txt
 ```
 
 ### Example 4: Archive all files in a specified location
 
 ```powershell
 PS ..\pwsh> $files = Get-ChildItem -File -Recurse
-PS ..\pwsh> $files | ForEach-Object {
-   New-ZipEntry .\test.zip -EntryPath $_.FullName.Remove(0, $pwd.Path.Length) -SourcePath $_.FullName
-}
+PS ..\pwsh> $files | ForEach-Object { New-ZipEntry .\test.zip -SourcePath $_.FullName }
 ```
 
-In this example `$_.FullName.Remove(0, $pwd.Path.Length)` is used to get the file paths relative to the current location. Using `-EntryPath $_.FullName` without getting the relative paths would work too however this would cause issues while attempting to extract the files later.
+> [!TIP]
+> The `-EntryPath` parameter is optional when creating an entry from a source file.
+> If the entry path isn't specified, the cmdlet will using the file's `.FullName` in its normalized form.
 
 ### Example 5: Archive all `.txt` files in a specified location using a specified encoding
 
@@ -115,9 +116,12 @@ In this example `$_.FullName.Remove(0, $pwd.Path.Length)` is used to get the fil
 PS ..\pwsh> $files = Get-ChildItem -File -Recurse -Filter *.txt
 PS ..\pwsh> $files | ForEach-Object {
    $_ | Get-Content -Encoding ascii |
-      New-ZipEntry .\test.zip -EntryPath $_.FullName.Remove(0, $pwd.Path.Length) -Encoding ascii
+      New-ZipEntry .\test.zip -EntryPath $_.FullName -Encoding ascii
 }
 ```
+
+> [!NOTE]
+> As opposed to previous example, when creating entries from input values, __the `-EntryPath` parameter is mandatory__. In this case, when using an absolute path as `-EntryPath` the cmdlet will always create the entries using their normalized form as explained in [__Description__](#description).
 
 ## PARAMETERS
 

--- a/docs/en-US/New-ZipEntry.md
+++ b/docs/en-US/New-ZipEntry.md
@@ -62,13 +62,13 @@ In addition, `New-ZipEntry` can set the content of the entries that it creates f
 ```powershell
 PS ..\pwsh> New-ZipEntry .\test.zip -EntryPath test\entry, newfolder\
 
-   Directory: newfolder/
+   Directory: /newfolder/
 
 Type                    LastWriteTime  CompressedSize            Size Name
 ----                    -------------  --------------            ---- ----
 Directory          2/24/2024  3:22 PM         0.00  B         0.00  B newfolder
 
-   Directory: test/
+   Directory: /test/
 
 Type                    LastWriteTime  CompressedSize            Size Name
 ----                    -------------  --------------            ---- ----

--- a/docs/en-US/Rename-ZipEntry.md
+++ b/docs/en-US/Rename-ZipEntry.md
@@ -15,8 +15,8 @@ Renames zip entries from one or more zip archives.
 
 ```powershell
 Rename-ZipEntry
-    [-ZipEntry] <ZipEntryBase>
-    [-NewName] <String>
+    -ZipEntry <ZipEntryBase>
+    -NewName <String>
     [-PassThru]
     [-WhatIf]
     [-Confirm]

--- a/docs/en-US/Rename-ZipEntry.md
+++ b/docs/en-US/Rename-ZipEntry.md
@@ -63,7 +63,7 @@ PS ..pwsh\> Get-ZipEntry .\myZip.zip -Type Archive -Include *.ext |
 ```powershell
 PS ..\pwsh> Get-ZipEntry .\PSCompression.zip -Include PSCompression/docs/en-US/*
 
-   Directory: PSCompression/docs/en-US/
+   Directory: /PSCompression/docs/en-US/
 
 Type                    LastWriteTime  CompressedSize            Size Name
 ----                    -------------  --------------            ---- ----
@@ -85,7 +85,7 @@ Archive            2/22/2024  1:19 PM         1.55 KB         5.35 KB Set-ZipEnt
 PS ..\pwsh> Get-ZipEntry .\PSCompression.zip -Include PSCompression/docs/en-US/ | Rename-ZipEntry -NewName 'en-US123'
 PS ..\pwsh> Get-ZipEntry .\PSCompression.zip -Include PSCompression/docs/en-US123/*
 
-   Directory: PSCompression/docs/en-US123/
+   Directory: /PSCompression/docs/en-US123/
 
 Type                    LastWriteTime  CompressedSize            Size Name
 ----                    -------------  --------------            ---- ----
@@ -123,7 +123,7 @@ Performing the operation "Rename" on target "PSCompression/docs/en-US123/".
 Specifies the new name of the zip entry. Enter only a name, not a path and name.
 
 > [!TIP]
-> [Delay-bind scriptblock](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_script_blocks?view=powershell-7.4#using-delay-bind-script-blocks-with-parameters) is supported for this parameter. See [Example 2](./Rename-ZipEntry.md#example-2-rename-all-entries-with-ext-extension-using-a-delay-bind-scriptblock).
+> [Delay-bind scriptblock](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_script_blocks?view=powershell-7.4#using-delay-bind-script-blocks-with-parameters) is supported for this parameter. See [Example 2](#example-2-rename-all-entries-with-ext-extension-using-a-delay-bind-scriptblock).
 
 ```yaml
 Type: String

--- a/docs/en-US/Set-ZipEntryContent.md
+++ b/docs/en-US/Set-ZipEntryContent.md
@@ -131,6 +131,7 @@ Accept wildcard characters: False
 ### -BufferSize
 
 For efficiency purposes this cmdlet buffers bytes before writing them to the Zip Archive Entry. This parameter determines how many bytes are buffered before being written to the stream.
+
 > [!NOTE]
 >
 > - __This parameter is applicable only when `-AsByteStream` is used.__

--- a/docs/en-US/Set-ZipEntryContent.md
+++ b/docs/en-US/Set-ZipEntryContent.md
@@ -18,7 +18,7 @@ Sets or appends content to an existing zip entry.
 ```powershell
 Set-ZipEntryContent
     -Value <Object[]>
-    [-SourceEntry] <ZipEntryFile>
+    -SourceEntry <ZipEntryFile>
     [-Encoding <Encoding>]
     [-Append]
     [-PassThru]
@@ -30,7 +30,7 @@ Set-ZipEntryContent
 ```powershell
 Set-ZipEntryContent
     -Value <Object[]>
-    [-SourceEntry] <ZipEntryFile>
+    -SourceEntry <ZipEntryFile>
     [-AsByteStream]
     [-Append]
     [-BufferSize <Int32>]

--- a/module/PSCompression.psd1
+++ b/module/PSCompression.psd1
@@ -11,7 +11,7 @@
     RootModule         = 'bin/netstandard2.0/PSCompression.dll'
 
     # Version number of this module.
-    ModuleVersion      = '2.0.7'
+    ModuleVersion      = '2.0.8'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/PSCompression/Commands/ConvertFromGzipStringCommand.cs
+++ b/src/PSCompression/Commands/ConvertFromGzipStringCommand.cs
@@ -3,8 +3,9 @@ using System.IO;
 using System.IO.Compression;
 using System.Management.Automation;
 using System.Text;
+using PSCompression.Exceptions;
 
-namespace PSCompression;
+namespace PSCompression.Commands;
 
 [Cmdlet(VerbsData.ConvertFrom, "GzipString")]
 [OutputType(typeof(string))]
@@ -44,14 +45,9 @@ public sealed class ConvertFromGzipStringCommand : PSCmdlet
                     WriteObject(reader.ReadLine());
                 }
             }
-            catch (Exception e) when (e is PipelineStoppedException or FlowControlException)
+            catch (Exception exception)
             {
-                throw;
-            }
-            catch (Exception e)
-            {
-                WriteError(new ErrorRecord(
-                    e, "ReadError", ErrorCategory.ReadError, line));
+                WriteError(exception.ToEnumerationError(line));
             }
         }
     }

--- a/src/PSCompression/Commands/ConvertToGzipStringCommand.cs
+++ b/src/PSCompression/Commands/ConvertToGzipStringCommand.cs
@@ -3,8 +3,9 @@ using System.IO;
 using System.IO.Compression;
 using System.Management.Automation;
 using System.Text;
+using PSCompression.Exceptions;
 
-namespace PSCompression;
+namespace PSCompression.Commands;
 
 [Cmdlet(VerbsData.ConvertTo, "GzipString")]
 [OutputType(typeof(byte[]), typeof(string))]
@@ -52,14 +53,9 @@ public sealed class ConvertToGzipStringCommand : PSCmdlet, IDisposable
 
             WriteLines(_writer, InputObject);
         }
-        catch (Exception e) when (e is PipelineStoppedException or FlowControlException)
+        catch (Exception exception)
         {
-            throw;
-        }
-        catch (Exception e)
-        {
-            WriteError(new ErrorRecord(
-                e, "WriteError", ErrorCategory.NotSpecified, InputObject));
+            WriteError(exception.ToWriteError(InputObject));
         }
     }
 
@@ -84,14 +80,9 @@ public sealed class ConvertToGzipStringCommand : PSCmdlet, IDisposable
 
             WriteObject(Convert.ToBase64String(_outstream.ToArray()));
         }
-        catch (Exception e) when (e is PipelineStoppedException or FlowControlException)
+        catch (Exception exception)
         {
-            throw;
-        }
-        catch (Exception e)
-        {
-            WriteError(new ErrorRecord(
-                e, "OutputError", ErrorCategory.NotSpecified, _outstream));
+            WriteError(exception.ToWriteError(_outstream));
         }
     }
 

--- a/src/PSCompression/Commands/ExpandGzipArchiveCommand.cs
+++ b/src/PSCompression/Commands/ExpandGzipArchiveCommand.cs
@@ -2,18 +2,18 @@ using System;
 using System.IO;
 using System.Management.Automation;
 using System.Text;
-using static PSCompression.Exceptions.ExceptionHelpers;
 using PSCompression.Extensions;
+using PSCompression.Exceptions;
 
-namespace PSCompression;
+namespace PSCompression.Commands;
 
 [Cmdlet(VerbsData.Expand, "GzipArchive")]
 [OutputType(
     typeof(string),
-    ParameterSetName = new[] { "Path", "LiteralPath" })]
+    ParameterSetName = ["Path", "LiteralPath"])]
 [OutputType(
     typeof(FileInfo),
-    ParameterSetName = new[] { "PathDestination", "LiteralPathDestination" })]
+    ParameterSetName = ["PathDestination", "LiteralPathDestination"])]
 [Alias("gzipfromfile")]
 public sealed class ExpandGzipArchiveCommand : PSCmdlet, IDisposable
 {
@@ -21,7 +21,7 @@ public sealed class ExpandGzipArchiveCommand : PSCmdlet, IDisposable
 
     private FileStream? _destination;
 
-    private string[] _paths = Array.Empty<string>();
+    private string[] _paths = [];
 
     [Parameter(
         ParameterSetName = "Path",
@@ -114,13 +114,9 @@ public sealed class ExpandGzipArchiveCommand : PSCmdlet, IDisposable
 
                 _destination = File.Open(Destination, GetMode());
             }
-            catch (Exception e) when (e is PipelineStoppedException or FlowControlException)
+            catch (Exception exception)
             {
-                throw;
-            }
-            catch (Exception e)
-            {
-                ThrowTerminatingError(StreamOpenError(Destination, e));
+                ThrowTerminatingError(exception.ToStreamOpenError(Destination));
             }
         }
     }
@@ -131,7 +127,7 @@ public sealed class ExpandGzipArchiveCommand : PSCmdlet, IDisposable
         {
             if (!path.IsArchive())
             {
-                WriteError(NotArchivePathError(
+                WriteError(ExceptionHelpers.NotArchivePathError(
                     path,
                     _isLiteral ? nameof(LiteralPath) : nameof(Path)));
 
@@ -157,13 +153,9 @@ public sealed class ExpandGzipArchiveCommand : PSCmdlet, IDisposable
                     encoding: Encoding,
                     cmdlet: this);
             }
-            catch (Exception e) when (e is PipelineStoppedException or FlowControlException)
+            catch (Exception exception)
             {
-                throw;
-            }
-            catch (Exception e)
-            {
-                WriteError(ZipOpenError(path, e));
+                WriteError(exception.ToOpenError(path));
             }
         }
     }

--- a/src/PSCompression/Commands/ExpandZipEntryCommand.cs
+++ b/src/PSCompression/Commands/ExpandZipEntryCommand.cs
@@ -2,9 +2,9 @@
 using System.IO;
 using System.Management.Automation;
 using PSCompression.Extensions;
-using static PSCompression.Exceptions.ExceptionHelpers;
+using PSCompression.Exceptions;
 
-namespace PSCompression;
+namespace PSCompression.Commands;
 
 [Cmdlet(VerbsData.Expand, "ZipEntry")]
 [OutputType(typeof(FileSystemInfo), ParameterSetName = new[] { "PassThru" })]
@@ -35,18 +35,14 @@ public sealed class ExpandZipEntryCommand : PSCmdlet, IDisposable
 
             if (File.Exists(Destination))
             {
-                ThrowTerminatingError(NotDirectoryPathError(
+                ThrowTerminatingError(ExceptionHelpers.NotDirectoryPathError(
                     Destination,
                     nameof(Destination)));
             }
         }
-        catch (Exception e) when (e is PipelineStoppedException or FlowControlException)
+        catch (Exception exception)
         {
-            throw;
-        }
-        catch (Exception e)
-        {
-            ThrowTerminatingError(ResolvePathError(Destination, e));
+            ThrowTerminatingError(exception.ToResolvePathError(Destination));
         }
     }
 
@@ -74,13 +70,9 @@ public sealed class ExpandZipEntryCommand : PSCmdlet, IDisposable
                     WriteObject(new DirectoryInfo(path));
                 }
             }
-            catch (Exception e) when (e is PipelineStoppedException or FlowControlException)
+            catch (Exception exception)
             {
-                throw;
-            }
-            catch (Exception e)
-            {
-                WriteError(ExtractEntryError(entry, e));
+                WriteError(exception.ToExtractEntryError(entry));
             }
         }
     }

--- a/src/PSCompression/Commands/GetZipEntryCommand.cs
+++ b/src/PSCompression/Commands/GetZipEntryCommand.cs
@@ -4,9 +4,9 @@ using System.IO.Compression;
 using System.Linq;
 using System.Management.Automation;
 using PSCompression.Extensions;
-using static PSCompression.Exceptions.ExceptionHelpers;
+using PSCompression.Exceptions;
 
-namespace PSCompression;
+namespace PSCompression.Commands;
 
 [Cmdlet(VerbsCommon.Get, "ZipEntry", DefaultParameterSetName = "Path")]
 [OutputType(typeof(ZipEntryDirectory), typeof(ZipEntryFile))]
@@ -19,7 +19,7 @@ public sealed class GetZipEntryCommand : PSCmdlet
 
     private bool _withExclude;
 
-    private string[] _paths = Array.Empty<string>();
+    private string[] _paths = [];
 
     private readonly List<ZipEntryBase> _output = new();
 
@@ -104,7 +104,7 @@ public sealed class GetZipEntryCommand : PSCmdlet
         {
             if (!path.IsArchive())
             {
-                WriteError(NotArchivePathError(
+                WriteError(ExceptionHelpers.NotArchivePathError(
                     path,
                     _isLiteral ? nameof(LiteralPath) : nameof(Path)));
 
@@ -115,13 +115,9 @@ public sealed class GetZipEntryCommand : PSCmdlet
             {
                 WriteObject(GetEntries(path), enumerateCollection: true);
             }
-            catch (Exception e) when (e is PipelineStoppedException or FlowControlException)
+            catch (Exception exception)
             {
-                throw;
-            }
-            catch (Exception e)
-            {
-                WriteError(ZipOpenError(path, e));
+                WriteError(exception.ToOpenError(path));
             }
         }
     }

--- a/src/PSCompression/Commands/NewZipEntryCommand.cs
+++ b/src/PSCompression/Commands/NewZipEntryCommand.cs
@@ -29,22 +29,17 @@ public sealed class NewZipEntryCommand : PSCmdlet, IDisposable
     [Parameter(Mandatory = true, Position = 0)]
     public string Destination { get; set; } = null!;
 
-    [Parameter(
-        ParameterSetName = "Value",
-        Mandatory = true,
-        Position = 1)]
-    [Parameter(
-        ParameterSetName = "File",
-        Position = 1)]
+    [Parameter(ParameterSetName = "File", Position = 1)]
+    [ValidateNotNullOrEmpty]
+    public string? SourcePath { get; set; }
+
+    [Parameter(ParameterSetName = "Value", Mandatory = true, Position = 2)]
+    [Parameter(ParameterSetName = "File", Position = 2)]
     public string[]? EntryPath
     {
         get => _entryPath;
         set => _entryPath = value.Select(e => e.NormalizePath()).ToArray();
     }
-
-    [Parameter(ParameterSetName = "File", Position = 2)]
-    [ValidateNotNullOrEmpty]
-    public string? SourcePath { get; set; }
 
     [Parameter]
     public CompressionLevel CompressionLevel { get; set; } = CompressionLevel.Optimal;

--- a/src/PSCompression/Commands/RemoveZipEntryCommand.cs
+++ b/src/PSCompression/Commands/RemoveZipEntryCommand.cs
@@ -1,9 +1,9 @@
 using System;
 using System.IO.Compression;
 using System.Management.Automation;
-using static PSCompression.Exceptions.ExceptionHelpers;
+using PSCompression.Exceptions;
 
-namespace PSCompression;
+namespace PSCompression.Commands;
 
 [Cmdlet(VerbsCommon.Remove, "ZipEntry", SupportsShouldProcess = true)]
 public sealed class RemoveZipEntryCommand : PSCmdlet, IDisposable
@@ -24,13 +24,9 @@ public sealed class RemoveZipEntryCommand : PSCmdlet, IDisposable
                     entry.Remove(_cache.GetOrAdd(entry));
                 }
             }
-            catch (Exception e) when (e is PipelineStoppedException or FlowControlException)
+            catch (Exception exception)
             {
-                throw;
-            }
-            catch (Exception e)
-            {
-                WriteError(ZipOpenError(entry.Source, e));
+                WriteError(exception.ToOpenError(entry.Source));
             }
         }
     }

--- a/src/PSCompression/Commands/SetZipEntryContentCommand.cs
+++ b/src/PSCompression/Commands/SetZipEntryContentCommand.cs
@@ -53,13 +53,9 @@ public sealed class SetZipEntryContentCommand : PSCmdlet, IDisposable
                 append: Append.IsPresent,
                 encoding: Encoding);
         }
-        catch (Exception e) when (e is PipelineStoppedException or FlowControlException)
+        catch (Exception exception)
         {
-            throw;
-        }
-        catch (Exception e)
-        {
-            ThrowTerminatingError(StreamOpenError(SourceEntry, e));
+            ThrowTerminatingError(exception.ToStreamOpenError(SourceEntry));
         }
     }
 
@@ -78,13 +74,9 @@ public sealed class SetZipEntryContentCommand : PSCmdlet, IDisposable
             _zipWriter.WriteLines(
                 LanguagePrimitives.ConvertTo<string[]>(Value));
         }
-        catch (Exception e) when (e is PipelineStoppedException or FlowControlException)
+        catch (Exception exception)
         {
-            throw;
-        }
-        catch (Exception e)
-        {
-            ThrowTerminatingError(ZipWriteError(SourceEntry, e));
+            ThrowTerminatingError(exception.ToWriteError(SourceEntry));
         }
     }
 
@@ -103,9 +95,9 @@ public sealed class SetZipEntryContentCommand : PSCmdlet, IDisposable
             SourceEntry.Refresh();
             WriteObject(SourceEntry);
         }
-        catch (Exception e)
+        catch (Exception exception)
         {
-            ThrowTerminatingError(StreamOpenError(SourceEntry, e));
+            ThrowTerminatingError(exception.ToStreamOpenError(SourceEntry));
         }
     }
 

--- a/src/PSCompression/EncodingArgumentCompleter.cs
+++ b/src/PSCompression/EncodingArgumentCompleter.cs
@@ -13,8 +13,8 @@ public sealed class EncodingCompleter : IArgumentCompleter
 
     static EncodingCompleter()
     {
-        List<string> set = new(new[]
-        {
+        List<string> set = new(
+        [
             "ascii",
             "bigendianUtf32",
             "unicode",
@@ -24,14 +24,14 @@ public sealed class EncodingCompleter : IArgumentCompleter
             "oem",
             "utf8BOM",
             "utf32"
-        });
+        ]);
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             set.Add("ansi");
         }
 
-        s_encodingSet = set.ToArray();
+        s_encodingSet = [.. set];
     }
 
     public IEnumerable<CompletionResult> CompleteArgument(

--- a/src/PSCompression/Exceptions/ExceptionHelpers.cs
+++ b/src/PSCompression/Exceptions/ExceptionHelpers.cs
@@ -20,7 +20,7 @@ internal static class ExceptionHelpers
         new(new ArgumentException($"Destination path is an existing File: '{path}'.", paramname),
             "NotDirectoryPath", ErrorCategory.InvalidArgument, path);
 
-    internal static ErrorRecord InvalidProviderError(string path, ProviderInfo provider) =>
+    internal static ErrorRecord ToInvalidProviderError(this ProviderInfo provider, string path) =>
         new(new ArgumentException($"The resolved path '{path}' is not a FileSystem path but '{provider.Name}'."),
             "NotFileSystemPath", ErrorCategory.InvalidArgument, path);
 

--- a/src/PSCompression/Exceptions/ExceptionHelpers.cs
+++ b/src/PSCompression/Exceptions/ExceptionHelpers.cs
@@ -24,41 +24,41 @@ internal static class ExceptionHelpers
         new(new ArgumentException($"The resolved path '{path}' is not a FileSystem path but '{provider.Name}'."),
             "NotFileSystemPath", ErrorCategory.InvalidArgument, path);
 
-    internal static ErrorRecord ZipOpenError(string path, Exception exception) =>
+    internal static ErrorRecord ToOpenError(this Exception exception, string path) =>
         new(exception, "ZipOpen", ErrorCategory.OpenError, path);
 
-    internal static ErrorRecord ResolvePathError(string path, Exception exception) =>
+    internal static ErrorRecord ToResolvePathError(this Exception exception, string path) =>
         new(exception, "ResolvePath", ErrorCategory.NotSpecified, path);
 
-    internal static ErrorRecord ExtractEntryError(ZipEntryBase entry, Exception exception) =>
+    internal static ErrorRecord ToExtractEntryError(this Exception exception, ZipEntryBase entry) =>
         new(exception, "ExtractEntry", ErrorCategory.NotSpecified, entry);
 
-    internal static ErrorRecord StreamOpenError(ZipEntryFile entry, Exception exception) =>
+    internal static ErrorRecord ToStreamOpenError(this Exception exception, ZipEntryFile entry) =>
         new(exception, "StreamOpen", ErrorCategory.NotSpecified, entry);
 
-    internal static ErrorRecord StreamOpenError(string path, Exception exception) =>
+    internal static ErrorRecord ToStreamOpenError(this Exception exception, string path) =>
         new(exception, "StreamOpen", ErrorCategory.NotSpecified, path);
 
-    internal static ErrorRecord ZipWriteError(object entry, Exception exception) =>
-        new(exception, "WriteError", ErrorCategory.WriteError, entry);
+    internal static ErrorRecord ToWriteError(this Exception exception, object? item) =>
+        new(exception, "WriteError", ErrorCategory.WriteError, item);
 
-    internal static ErrorRecord DuplicatedEntryError(DuplicatedEntryException exception) =>
+    internal static ErrorRecord ToDuplicatedEntryError(this DuplicatedEntryException exception) =>
         new(exception, "DuplicatedEntry", ErrorCategory.WriteError, exception._path);
 
-    internal static ErrorRecord InvalidNameError(string name, InvalidNameException exception) =>
+    internal static ErrorRecord ToInvalidNameError(this InvalidNameException exception, string name) =>
         new(exception, "InvalidName", ErrorCategory.InvalidArgument, name);
 
-    internal static ErrorRecord EntryNotFoundError(EntryNotFoundException exception) =>
+    internal static ErrorRecord ToEntryNotFoundError(this EntryNotFoundException exception) =>
         new(exception, "EntryNotFound", ErrorCategory.ObjectNotFound, exception._path);
 
-    internal static ErrorRecord EnumerationError(object item, Exception exception) =>
+    internal static ErrorRecord ToEnumerationError(this Exception exception, object item) =>
         new(exception, "EnumerationError", ErrorCategory.ReadError, item);
 
     internal static void ThrowIfNotFound(
-    this ZipArchive zip,
-    string path,
-    string source,
-    out ZipArchiveEntry entry)
+        this ZipArchive zip,
+        string path,
+        string source,
+        out ZipArchiveEntry entry)
     {
         if (!zip.TryGetEntry(path, out entry))
         {

--- a/src/PSCompression/GzipReaderOps.cs
+++ b/src/PSCompression/GzipReaderOps.cs
@@ -8,12 +8,7 @@ namespace PSCompression;
 
 internal static class GzipReaderOps
 {
-    private static readonly byte[] gzipPreamble = new byte[]
-    {
-        0x1f,
-        0x8b,
-        0x08
-    };
+    private static readonly byte[] gzipPreamble = [0x1f, 0x8b, 0x08];
 
     internal static void CopyTo(
         string path,

--- a/src/PSCompression/ZipContentOpsBase.cs
+++ b/src/PSCompression/ZipContentOpsBase.cs
@@ -15,9 +15,7 @@ internal abstract class ZipContentOpsBase : IDisposable
         ZipArchive = zip;
 
     protected ZipContentOpsBase()
-    {
-
-    }
+    { }
 
     protected virtual void Dispose(bool disposing)
     {

--- a/src/PSCompression/ZipContentReader.cs
+++ b/src/PSCompression/ZipContentReader.cs
@@ -10,9 +10,7 @@ internal sealed class ZipContentReader : ZipContentOpsBase
 {
     internal ZipContentReader(ZipArchive zip)
         : base(zip)
-    {
-
-    }
+    { }
 
     private Stream GetStream(string entry) =>
         ZipArchive.GetEntry(entry).Open();
@@ -54,7 +52,6 @@ internal sealed class ZipContentReader : ZipContentOpsBase
     {
         using Stream entryStream = GetStream(entry);
         using StreamReader reader = new(entryStream, encoding);
-
         return reader.ReadToEnd();
     }
 }

--- a/src/PSCompression/ZipEntryBase.cs
+++ b/src/PSCompression/ZipEntryBase.cs
@@ -14,6 +14,10 @@ public enum ZipEntryType
 
 public abstract class ZipEntryBase
 {
+    protected string? _formatDirectoryPath;
+
+    internal abstract string FormatDirectoryPath { get; }
+
     public string Source { get; }
 
     public string Name { get; protected set; }

--- a/src/PSCompression/ZipEntryDirectory.cs
+++ b/src/PSCompression/ZipEntryDirectory.cs
@@ -10,6 +10,11 @@ public sealed class ZipEntryDirectory : ZipEntryBase
 {
     private const StringComparison _comparer = StringComparison.InvariantCultureIgnoreCase;
 
+    internal override string FormatDirectoryPath
+    {
+        get => _formatDirectoryPath ??= $"/{RelativePath.NormalizeEntryPath()}";
+    }
+
     public override ZipEntryType Type => ZipEntryType.Directory;
 
     internal ZipEntryDirectory(ZipArchiveEntry entry, string source)

--- a/src/PSCompression/ZipEntryFile.cs
+++ b/src/PSCompression/ZipEntryFile.cs
@@ -15,9 +15,7 @@ public sealed class ZipEntryFile : ZipEntryBase
 
     internal ZipEntryFile(ZipArchiveEntry entry, string source)
         : base(entry, source)
-    {
-
-    }
+    { }
 
     private static string GetRatio(long size, long compressedSize)
     {

--- a/src/PSCompression/ZipEntryFile.cs
+++ b/src/PSCompression/ZipEntryFile.cs
@@ -1,10 +1,17 @@
 using System.IO;
 using System.IO.Compression;
+using PSCompression.Extensions;
 
 namespace PSCompression;
 
 public sealed class ZipEntryFile : ZipEntryBase
 {
+    internal override string FormatDirectoryPath
+    {
+        get => _formatDirectoryPath ??=
+            $"/{Path.GetDirectoryName(RelativePath).NormalizeEntryPath()}";
+    }
+
     public string CompressionRatio => GetRatio(Length, CompressedLength);
 
     public override ZipEntryType Type => ZipEntryType.Archive;

--- a/src/PSCompression/internal/_Format.cs
+++ b/src/PSCompression/internal/_Format.cs
@@ -28,19 +28,7 @@ public static class _Format
     ];
 
     [Hidden, EditorBrowsable(EditorBrowsableState.Never)]
-    public static string GetDirectoryPath(ZipEntryBase entry)
-    {
-        if (entry is ZipEntryDirectory)
-        {
-            return $"/{entry.RelativePath.NormalizeEntryPath()}";
-        }
-
-        string path = Path
-            .GetDirectoryName(entry.RelativePath)
-            .NormalizeEntryPath();
-
-        return string.IsNullOrEmpty(path) ? "/" : $"/{path}";
-    }
+    public static string GetDirectoryPath(ZipEntryBase entry) => entry.FormatDirectoryPath;
 
     [Hidden, EditorBrowsable(EditorBrowsableState.Never)]
     public static string GetFormattedDate(DateTime dateTime) =>

--- a/src/PSCompression/internal/_Format.cs
+++ b/src/PSCompression/internal/_Format.cs
@@ -12,10 +12,10 @@ namespace PSCompression.Internal;
 [EditorBrowsable(EditorBrowsableState.Never)]
 public static class _Format
 {
-    private static CultureInfo _culture = CultureInfo.CurrentCulture;
+    private static readonly CultureInfo _culture = CultureInfo.CurrentCulture;
 
     private readonly static string[] s_suffix =
-    {
+    [
         "B",
         "KB",
         "MB",
@@ -25,26 +25,21 @@ public static class _Format
         "EB",
         "ZB",
         "YB"
-    };
+    ];
 
     [Hidden, EditorBrowsable(EditorBrowsableState.Never)]
     public static string GetDirectoryPath(ZipEntryBase entry)
     {
         if (entry is ZipEntryDirectory)
         {
-            return entry.RelativePath.NormalizeEntryPath();
+            return $"/{entry.RelativePath.NormalizeEntryPath()}";
         }
 
         string path = Path
             .GetDirectoryName(entry.RelativePath)
             .NormalizeEntryPath();
 
-        if (string.IsNullOrEmpty(path))
-        {
-            return "/";
-        }
-
-        return path;
+        return string.IsNullOrEmpty(path) ? "/" : $"/{path}";
     }
 
     [Hidden, EditorBrowsable(EditorBrowsableState.Never)]

--- a/tests/ZipEntryCmdlets.tests.ps1
+++ b/tests/ZipEntryCmdlets.tests.ps1
@@ -89,6 +89,26 @@ Describe 'ZipEntry Cmdlets' {
                 Get-ZipEntryContent |
                 Should -Be 'hello world!'
         }
+
+        It 'Can create entries with content from file without specifying an EntryPath' {
+            $newItemSplat = @{
+                ItemType = 'File'
+                Force    = $true
+                Path     = (Join-Path $TestDrive helloworld.txt)
+            }
+
+            $item = 'hello world!' | New-Item @newItemSplat
+
+            $newZipEntrySplat = @{
+                SourcePath  = $item.FullName
+                Destination = $zip.FullName
+            }
+
+            $entry = New-ZipEntry @newZipEntrySplat
+            $entry | Get-ZipEntryContent | Should -Be 'hello world!'
+            $entry.RelativePath |
+                Should -Be ([PSCompression.Extensions.PathExtensions]::NormalizePath($item.FullName))
+        }
     }
 
     Context 'Get-ZipEntry' -Tag 'Get-ZipEntry' {


### PR DESCRIPTION
- Makes `-EntryPath` no longer Mandatory on `File` ParameterSet. When no `-EntryPath` is specified the cmdlet will use the `-SourcePath` in it's normalized form.
- Added Pester tests and updated docs to reflect this change.
- Updated all docs __Syntax__ section to properly reflect Mandatory parameters.