### PR TITLE
Fix `EncodingTransformation` for `Encoding` and `int` instances wrapped in `PSObject`

### DIFF
--- a/module/PSCompression.psd1
+++ b/module/PSCompression.psd1
@@ -11,7 +11,7 @@
     RootModule         = 'bin/netstandard2.0/PSCompression.dll'
 
     # Version number of this module.
-    ModuleVersion      = '2.0.9'
+    ModuleVersion      = '2.0.10'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/PSCompression/EncodingTransformation.cs
+++ b/src/PSCompression/EncodingTransformation.cs
@@ -9,16 +9,21 @@ public sealed class EncodingTransformation : ArgumentTransformationAttribute
 {
     public override object Transform(
         EngineIntrinsics engineIntrinsics,
-        object inputData) =>
-        inputData switch
+        object inputData)
+    {
+        inputData = inputData is PSObject pso
+            ? pso.BaseObject
+            : inputData;
+
+        return inputData switch
         {
             Encoding enc => enc,
             int num => Encoding.GetEncoding(num),
             string str => ParseStringEncoding(str),
-            PSObject pso when pso.BaseObject is string str => ParseStringEncoding(str),
             _ => throw new ArgumentTransformationMetadataException(
                 $"Could not convert input '{inputData}' to a valid Encoding object."),
         };
+    }
 
     private Encoding ParseStringEncoding(string str) =>
         str.ToLowerInvariant() switch

--- a/tests/ZipEntryCmdlets.tests.ps1
+++ b/tests/ZipEntryCmdlets.tests.ps1
@@ -158,11 +158,18 @@ Describe 'ZipEntry Cmdlets' {
                 Should -BeOfType ([string])
         }
 
-        It 'Should not throw when a string wrapped in PSObject is passed as Encdoing argument' {
+        It 'Should not throw when an instance wrapped in PSObject is passed as Encdoing argument' {
             $enc = Write-Output utf8
-            $zip | Get-ZipEntry -Type Archive |
-                Get-ZipEntryContent -Encoding $enc |
-                Should -BeOfType ([string])
+            { $zip | Get-ZipEntry -Type Archive | Get-ZipEntryContent -Encoding $enc } |
+                Should -Not -Throw
+
+            $enc = [System.Text.Encoding]::UTF8 | Write-Output
+            { $zip | Get-ZipEntry -Type Archive | Get-ZipEntryContent -Encoding $enc } |
+                Should -Not -Throw
+
+            $enc = [System.Text.Encoding]::UTF8.CodePage | Write-Output
+            { $zip | Get-ZipEntry -Type Archive | Get-ZipEntryContent -Encoding $enc } |
+                Should -Not -Throw
         }
 
         It 'Can read bytes from zip file entries' {


### PR DESCRIPTION
Same issue as #34 but when `Encoding` and `int` instances are wrapped in `PSObject`:

```powershell
$utf8 = [System.Text.Encoding]::UTF8 | Write-Output
Get-ZipEntry .\test.zip | Get-ZipEntryContent -Encoding $utf8

# Get-ZipEntryContent: Cannot process argument transformation on parameter 'Encoding'.
#                      Could not convert input 'System.Text.UTF8Encoding+UTF8EncodingSealed' to a valid Encoding object.

$utf8 = [System.Text.Encoding]::UTF8.CodePage | Write-Output
Get-ZipEntry .\test.zip | Get-ZipEntryContent -Encoding $utf8

# Get-ZipEntryContent: Cannot process argument transformation on parameter 'Encoding'.
#                      Could not convert input '65001' to a valid Encoding object.
```